### PR TITLE
Adjust apply change behavior

### DIFF
--- a/src/chatroom/state_machine/state_machine.py
+++ b/src/chatroom/state_machine/state_machine.py
@@ -125,7 +125,15 @@ class StateMachine:
             try:
                 topic.ApplyChange(change)
             except:
-                # remove the appended command
+                # undo the whole subtree
+                while self._current_transition[-1] != command:
+                    topic = self._current_transition[-1].topic_name
+                    change = self._current_transition[-1].change
+                    self.GetTopic(topic).ApplyChange(change.Inverse(), notify_listeners=False)
+                    
+                    del self._current_transition[-1]
+                    del self._changes_made[-1]
+
                 del self._current_transition[-1]
                 del self._changes_made[-1]
                 raise

--- a/src/chatroom/state_machine/state_machine.py
+++ b/src/chatroom/state_machine/state_machine.py
@@ -29,7 +29,6 @@ class StateMachine:
         self._changes_made : List[ChangeCommand] = []
         self._on_changes_made = on_changes_made
         self._on_transition_done = on_transition_done
-        self._error_has_occured_in_transition = False
         self._recursion_enabled = True
         self._apply_change_call_stack = []
     
@@ -76,13 +75,8 @@ class StateMachine:
             raise
         else:
             self._isRecording = False
-            if self._error_has_occured_in_transition:
-                print("An error has occured in the transition but was catched by the user code. Cleaning up the failed transition.")
-                self._CleanupFailedTransition()
-                raise Exception("An error has occured in the transition but was catched by the user code.")
-            else:
-                newTransition = Transition(self._current_transition,actionSource)
-                self._on_transition_done(newTransition)
+            newTransition = Transition(self._current_transition,actionSource)
+            self._on_transition_done(newTransition)
         finally:
             self._isRecording = False
             self._NotifyChanges()
@@ -126,16 +120,15 @@ class StateMachine:
         with self._TrackApplyChange(command.topic_name):
             topic,change = self.GetTopic(command.topic_name),command.change
 
-            try:
-                old_value,new_value = topic.ApplyChange(change,notify_listeners=False) # If a exception is raised here, the change is not applied and the command is not added to the _current_transition
-            except Exception:
-                self._error_has_occured_in_transition = True
-                raise
-
             self._current_transition.append(command)
             self._changes_made.append(command)
-
-            topic.NotifyListeners(command.change,old_value,new_value) # If a exception is raised here,the command is added to the _current_transition. The cleanup process will undo the change.
+            try:
+                topic.ApplyChange(change)
+            except:
+                # remove the appended command
+                del self._current_transition[-1]
+                del self._changes_made[-1]
+                raise
 
     def Undo(self, transition: Transition):
         raise NotImplementedError

--- a/src/chatroom/topic.py
+++ b/src/chatroom/topic.py
@@ -86,7 +86,11 @@ class Topic(metaclass = abc.ABCMeta):
         new_value = self._ValidateChangeAndGetResult(change)
         self._value = new_value
         if notify_listeners:
-            self.NotifyListeners(change,old_value=old_value,new_value=self._value)
+            try:
+                self.NotifyListeners(change,old_value=old_value,new_value=self._value)
+            except:
+                self._value = old_value
+                raise
         return old_value,new_value
 
     @abc.abstractmethod

--- a/unittest/test_state_machine.py
+++ b/unittest/test_state_machine.py
@@ -72,13 +72,11 @@ class StateMachineTransition(unittest.TestCase):
         a.on_set += lambda value: b.Set('hello '+value)
         b.on_set += lambda value: c.Set(value+'!')
         b.AddValidator(lambda old,new,change: new != 'hello world')
-        with self.assertRaises(Exception) as cm:
-            with machine.Record():
-                try:
-                    a.Set('world')
-                except InvalidChangeException:
-                    pass
-        print(cm.exception)
+        with machine.Record():
+            try:
+                a.Set('world')
+            except InvalidChangeException:
+                pass
         self.assertEqual(a.GetValue(),'')
         self.assertEqual(b.GetValue(),'')
         self.assertEqual(c.GetValue(),'')
@@ -91,4 +89,81 @@ class StateMachineTransition(unittest.TestCase):
         self.assertEqual(b.GetValue(),'hello Eric')
         self.assertEqual(c.GetValue(),'hello Eric!')
         self.assertEqual(list(map(lambda change: change.topic_name,changes_list[1])),['a','b','c'])
+    
+    def test_prevent_recursive_change(self):
+        changes_list = []
+        transition_list = []
+        machine = StateMachine(on_changes_made=lambda changes:changes_list.append(changes),on_transition_done=lambda transition: transition_list.append(transition))
+        machine.AddTopic(a:=StringTopic('a',machine))
+        machine.AddTopic(b:=StringTopic('b',machine))
+        machine.AddTopic(c:=StringTopic('c',machine))
+        a.on_set += lambda value: b.Set('hello '+value)
+        b.on_set += lambda value: c.Set(value+'!')
+        c.on_set += lambda value: a.Set('NO ' + value)
+        with machine.Record():
+            a.Set('world')
+
+        self.assertEqual(a.GetValue(),'world')
+        self.assertEqual(b.GetValue(),'hello world')
+        self.assertEqual(c.GetValue(),'hello world!')
+        self.assertEqual(list(map(lambda change: change.topic_name,changes_list[0])),['a', 'b', 'c'])
+
+    def test_fail_set_without_except(self):
+        changes_list = []
+        machine = StateMachine(on_changes_made=lambda changes:changes_list.append(changes))
+        machine.AddTopic(a:=StringTopic('a',machine))
+        machine.AddTopic(b:=StringTopic('b',machine))
+        b.AddValidator(lambda old,new,change: False)
+        with self.assertRaises(InvalidChangeException):
+            with machine.Record():
+                a.Set('world')
+                b.Set('test')
         
+        self.assertEqual(a.GetValue(), '')
+        self.assertEqual(b.GetValue(), '')
+        self.assertEqual(list(map(lambda change: change.topic_name,changes_list[0])),[])
+
+    def test_fail_set_with_except(self):
+        changes_list = []
+        machine = StateMachine(on_changes_made=lambda changes:changes_list.append(changes))
+        machine.AddTopic(a:=StringTopic('a',machine))
+        machine.AddTopic(b:=StringTopic('b',machine))
+        machine.AddTopic(c:=StringTopic('c',machine))
+        b.AddValidator(lambda old,new,change: new != 'test')
+        with machine.Record():
+            a.Set('hello')
+            try:
+                b.Set('test')
+            except:
+                b.Set('test1')
+            c.Set('world')
+        
+        self.assertEqual(a.GetValue(), 'hello')
+        self.assertEqual(b.GetValue(), 'test1')
+        self.assertEqual(c.GetValue(), 'world')
+        self.assertEqual(list(map(lambda change: change.topic_name,changes_list[0])),['a', 'b', 'c'])
+
+    def test_try_except_in_on_set(self):
+        changes_list = []
+        machine = StateMachine(on_changes_made=lambda changes:changes_list.append(changes))
+        machine.AddTopic(a:=StringTopic('a',machine))
+        machine.AddTopic(b:=StringTopic('b',machine))
+        machine.AddTopic(c:=StringTopic('c',machine))
+        c.AddValidator(lambda old,new,change: False)
+        a.on_set += lambda value: b.Set(value + ' world')
+
+        def try_on_set(value):
+            try:
+                c.Set('invalid')
+            except:
+                pass 
+
+        b.on_set += try_on_set
+
+        with machine.Record():
+            a.Set('hello')
+        
+        self.assertEqual(a.GetValue(), 'hello')
+        self.assertEqual(b.GetValue(), 'hello world')
+        self.assertEqual(c.GetValue(), '')
+        self.assertEqual(list(map(lambda change: change.topic_name,changes_list[0])),['a', 'b'])


### PR DESCRIPTION
1. Users are allowed to handle exceptions from ApplyChange
2. Unhandled exceptions will cause the whole subtree to be reverted until it's handled. The whole transition is reverted if an exception isn't handled before it reaches the root (record).
3. A lot of tests were added to describe the intended revert behavior in various situations.