### PR TITLE
Test change serialize/deserialize

### DIFF
--- a/src/chatroom/change.py
+++ b/src/chatroom/change.py
@@ -96,6 +96,16 @@ class SetChange(Change):
         return self.__class__(self.topic_name,copy.deepcopy(self.old_value),copy.deepcopy(self.value))
     def serialize(self):
         return {"topic_name":self.topic_name,"topic_type":"unknown","type":"set","value":self.value,"old_value":self.old_value,"id":self.id}
+    def __eq__(self, other):
+        if type(self) != type(other):
+            # type will return the immediate type (simply, subtype), so we use type and compare them directly
+            # simple subclass of SetChange therefore don't need to write their own __eq__ method
+            return False
+        return self.topic_name == other.topic_name and \
+            self.value == other.value and \
+            self.old_value == other.old_value and \
+            self.id == other.id
+
 
 class GenericChangeTypes:
     class SetChange(SetChange):
@@ -126,6 +136,12 @@ class IntChangeTypes:
             return {"topic_name":self.topic_name,"topic_type":"int","type":"add","value":self.value,"id":self.id}
         def inverse(self)->Change:
             return IntChangeTypes.AddChange(self.topic_name,-self.value)
+        def __eq__(self, other):
+            if not isinstance(other, IntChangeTypes.AddChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.value == other.value and \
+                self.id == other.id
     
     types = {'set':SetChange,'add':AddChange}
 
@@ -144,6 +160,12 @@ class FloatChangeTypes:
             return {"topic_name":self.topic_name,"topic_type":"float","type":"add","value":self.value,"id":self.id}
         def inverse(self)->Change:
             return IntChangeTypes.AddChange(self.topic_name,-self.value)
+        def __eq__(self, other):
+            if not isinstance(other, FloatChangeTypes.AddChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.value == other.value and \
+                self.id == other.id
     
     types = {'set':SetChange,'add':AddChange}
 
@@ -163,6 +185,12 @@ class SetChangeTypes:
             return {"topic_name":self.topic_name,"topic_type":"set","type":"append","item":self.item,"id":self.id}
         def inverse(self)->Change:
             return SetChangeTypes.RemoveChange(self.topic_name,self.item)
+        def __eq__(self, other):
+            if not isinstance(other, SetChangeTypes.AppendChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.item == other.item and \
+                self.id == other.id
         
     class RemoveChange(Change):
         def __init__(self,topic_name, item,id=None):
@@ -178,6 +206,12 @@ class SetChangeTypes:
             return {"topic_name":self.topic_name,"topic_type":"set","type":"remove","item":self.item,"id":self.id}
         def inverse(self)->Change:
             return SetChangeTypes.AppendChange(self.topic_name,self.item)
+        def __eq__(self, other):
+            if not isinstance(other, SetChangeTypes.RemoveChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.item == other.item and \
+                self.id == other.id
     
     types = {'set':SetChange,'append':AppendChange,'remove':RemoveChange}
 
@@ -200,7 +234,14 @@ class ListChangeTypes:
             return {"topic_name":self.topic_name,"topic_type":"list","type":"insert","item":self.item,"position":self.position,"id":self.id}
         def inverse(self)->Change:
             return ListChangeTypes.PopChange(self.topic_name,self.item)
-        
+        def __eq__(self, other):
+            if not isinstance(other, ListChangeTypes.InsertChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.item == other.item and \
+                self.position == other.position and \
+                self.id == other.id
+
     class PopChange(Change):
         def __init__(self,topic_name, position,id=None):
             super().__init__(topic_name,id)
@@ -214,6 +255,14 @@ class ListChangeTypes:
             return {"topic_name":self.topic_name,"topic_type":"list","type":"pop","position":self.position,"id":self.id}
         def inverse(self)->Change:
             return ListChangeTypes.InsertChange(self.topic_name,self.item,self.position)
+        def __eq__(self, other):
+            if not isinstance(other, ListChangeTypes.PopChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.position == other.position and \
+                self.id == other.id
+
+    types = {'set': SetChange, 'insert': InsertChange, 'pop': PopChange}
 
 class DictChangeTypes:
     class SetChange(SetChange):
@@ -233,6 +282,13 @@ class DictChangeTypes:
             return {"topic_name":self.topic_name,"topic_type":"dict","type":"add","key":self.key,"value":self.value,"id":self.id}
         def inverse(self)->Change:
             return DictChangeTypes.RemoveChange(self.topic_name,self.key)
+        def __eq__(self, other):
+            if not isinstance(other, DictChangeTypes.AddChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.key == other.key and \
+                self.value == other.value and \
+                self.id == other.id
     class RemoveChange(Change):
         def __init__(self,topic_name, key,id=None):
             super().__init__(topic_name,id)
@@ -247,6 +303,12 @@ class DictChangeTypes:
             return {"topic_name":self.topic_name,"topic_type":"dict","type":"remove","key":self.key,"id":self.id}
         def inverse(self)->Change:
             return DictChangeTypes.AddChange(self.topic_name,self.key,self.value)
+        def __eq__(self, other):
+            if not isinstance(other, DictChangeTypes.RemoveChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.key == other.key and \
+                self.id == other.id
     class ChangeValueChange(Change):
         def __init__(self,topic_name, key,value,old_value=None,id=None):
             super().__init__(topic_name,id)
@@ -266,20 +328,35 @@ class DictChangeTypes:
             return {"topic_name":self.topic_name,"topic_type":"dict","type":"change_value","key":self.key,"value":self.value,"old_value":self.old_value,"id":self.id}
         def inverse(self)->Change:
             return DictChangeTypes.ChangeValueChange(self.topic_name,self.key,self.old_value,self.value)
+        def __eq__(self, other):
+            if not isinstance(other, DictChangeTypes.ChangeValueChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.key == other.key and \
+                self.value == other.value and \
+                self.old_value == other.old_value and \
+                self.id == other.id
     types = {'set':SetChange,'add':AddChange,'remove':RemoveChange,'change_value':ChangeValueChange}
 
 class EventChangeTypes:
     class EmitChange(Change):
-        def __init__(self,topic_name,args={},id=None):
+        def __init__(self,topic_name,args={},forward_info={},id=None):
             super().__init__(topic_name,id)
             self.args = args
-            self.forward_info = {}
+            self.forward_info = forward_info
         def apply(self,old_value:None):
             return None
         def serialize(self):
             return {"topic_name":self.topic_name,"topic_type":"event","type":"emit","args":self.args,"forward_info":self.forward_info,"id":self.id}
         def inverse(self)->Change:
             return EventChangeTypes.ReversedEmitChange(self.topic_name,self.args,self.forward_info)
+        def __eq__(self, other):
+            if not isinstance(other, EventChangeTypes.EmitChange):
+                return False
+            return self.topic_name == other.topic_name and \
+                self.args == other.args and \
+                self.forward_info == other.forward_info and \
+                self.id == other.id
     class ReversedEmitChange(Change):
             def __init__(self,topic_name,args={},forward_info={},id=None):
                 super().__init__(topic_name,id)
@@ -291,6 +368,13 @@ class EventChangeTypes:
                 return {"topic_name":self.topic_name,"topic_type":"event","type":"reversed_emit","args":self.args,"forward_info":self.forward_info,"id":self.id}
             def inverse(self)->Change:
                 return EventChangeTypes.EmitChange(self.topic_name,self.args)
+            def __eq__(self, other):
+                if not isinstance(other, EventChangeTypes.ReversedEmitChange):
+                    return False
+                return self.topic_name == other.topic_name and \
+                    self.args == other.args and \
+                    self.forward_info == other.forward_info and \
+                    self.id == other.id
     types = {'emit':EmitChange,'reversed_emit':ReversedEmitChange}
 
 class BinaryChangeTypes:

--- a/unittest/test_change_serialize.py
+++ b/unittest/test_change_serialize.py
@@ -1,0 +1,91 @@
+import unittest
+from chatroom.change import *
+
+
+# Test serialize/deserialize of concrete changes
+class TestChangeSerialize(unittest.TestCase):
+    def test_null_change_exception(self):
+        change = NullChange('topic')
+        with self.assertRaises(NotImplementedError):
+            change.serialize()
+
+    def _test_serializable(self, change):
+        serialized = change.serialize()
+        restored = Change.deserialize(serialized)
+        self.assertEqual(change, restored)
+
+    def test_generic_set(self):
+        change = GenericChangeTypes.SetChange('topic', 0, 1)
+        self._test_serializable(change)
+
+    def test_string_set(self):
+        change = StringChangeTypes.SetChange('topic', 'val', 'oval')
+        self._test_serializable(change)
+
+    def test_int_set(self):
+        change = IntChangeTypes.SetChange('topic', 0, 1)
+        self._test_serializable(change)
+
+    def test_int_add(self):
+        change = IntChangeTypes.AddChange('topic', 10)
+        self._test_serializable(change)
+
+    def test_float_set(self):
+        change = FloatChangeTypes.SetChange('topic', 0.5, 0.8)
+        self._test_serializable(change)
+
+    def test_float_add(self):
+        change = FloatChangeTypes.AddChange('topic', 0.2)
+        self._test_serializable(change)
+        
+    def test_set_set(self):
+        change = SetChangeTypes.SetChange('topic', [1, 2], [1])
+        self._test_serializable(change)
+        
+    def test_set_append(self):
+        change = SetChangeTypes.AppendChange('topic', 4)
+        self._test_serializable(change)
+        
+    def test_set_remove(self):
+        change = SetChangeTypes.RemoveChange('topic', 10)
+        self._test_serializable(change)
+        
+    def test_list_set(self):
+        change = ListChangeTypes.SetChange('topic', [1], [])
+        self._test_serializable(change)
+        
+    def test_list_insert(self):
+        change = ListChangeTypes.InsertChange('topic', 4, 10)
+        self._test_serializable(change)
+    
+    def test_list_pop(self):
+        change = ListChangeTypes.PopChange('topic', 3)
+        self._test_serializable(change)
+        
+    def test_dict_set(self):
+        change = DictChangeTypes.SetChange('topic', {'a': 3, 'b': 10}, {})
+        self._test_serializable(change)
+        
+    def test_dict_add(self):
+        change = DictChangeTypes.AddChange('topic', 'k', 'v')
+        self._test_serializable(change)
+        
+    def test_dict_remove(self):
+        change = DictChangeTypes.RemoveChange('topic', 'k')
+        self._test_serializable(change)
+        
+    def test_dict_change_value(self):
+        change = DictChangeTypes.ChangeValueChange('topic', 'k', 'v10', 'v')
+        self._test_serializable(change)
+
+    def test_event_emit(self):
+        change = EventChangeTypes.EmitChange('topic', {'arg1': 0, 'arg2': 10.0}, {'f1': '1', 'f2': 10})
+        self._test_serializable(change)
+
+    def test_event_reversed_emit(self):
+        change = EventChangeTypes.ReversedEmitChange('topic', {'arg1': 5}, {'f2': 1})
+        self._test_serializable(change)
+
+    def test_binary_set(self):
+        change = BinaryChangeTypes.SetChange('topic', 'bbb', '')
+        self._test_serializable(change)


### PR DESCRIPTION
1. Add tests for change serialize/deserialize
2. Fix `EventChangeTypes.EmitChange.__init__` argument mismatch
3. Add `ListChangeTypes.types` attribute for deserialize to work

2 and 3 may indicate that doing all this serializing thing by hand isn't wise and may result in errors.