### PR TITLE
Remove BinaryTopic

### DIFF
--- a/src/chatroom/change.py
+++ b/src/chatroom/change.py
@@ -27,8 +27,7 @@ default_topic_value = {
     'set':[],
     'list':[],
     'dict':{},
-    'event':None,
-    'binary':None
+    'event':None
 }
 
 def remove_entry(dictionary,key):
@@ -377,15 +376,6 @@ class EventChangeTypes:
                     self.id == other.id
     types = {'emit':EmitChange,'reversed_emit':ReversedEmitChange}
 
-class BinaryChangeTypes:
-    class SetChange(SetChange):
-        def serialize(self):
-            serialized = super().serialize()
-            serialized['topic_type'] = 'binary'
-            return serialized
-
-    types = {'set': SetChange}
-
 type_name_to_change_types = {
                                 'generic':GenericChangeTypes,
                                 'string':StringChangeTypes,
@@ -394,6 +384,5 @@ type_name_to_change_types = {
                                 'set':SetChangeTypes,
                                 'dict':DictChangeTypes,
                                 'list':ListChangeTypes,
-                                'event':EventChangeTypes,
-                                'binary':BinaryChangeTypes
+                                'event':EventChangeTypes
                             }

--- a/unittest/test_change_deserialize.py
+++ b/unittest/test_change_deserialize.py
@@ -74,7 +74,3 @@ class TestChangeDeserialize(unittest.TestCase):
     def test_dict_change_value(self):
         change = DictChangeTypes.ChangeValueChange('topic', 'k', 'v10', 'v')
         self._test_deserializable(change)
-
-    def test_binary_set(self):
-        change = BinaryChangeTypes.SetChange('topic', 'bbb', '')
-        self._test_deserializable(change)


### PR DESCRIPTION
1. Remove BinaryTopic, the responsibility is moved to StringTopic's new method `to_binary` and `set_from_binary`
2. Remove BinaryChangeTypes

This pr pairs with https://github.com/eri24816/ChatRoomClient_ts/pull/2